### PR TITLE
Implement DONSUS_STRING detection, resolve DONSUS_NUMBER problem.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/cmake-build-debug/
+/.idea/

--- a/Donsus/main.c
+++ b/Donsus/main.c
@@ -16,7 +16,6 @@ int main (int argc, char **argv){
     if (argc <= 1) print_usage();
 
     printf("Donsus compiler %s\n", VERSION_STRING);
-
     return Du_Main(argc, argv); // start layer 1 main
 
 };

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -16,10 +16,6 @@ int du_run_command(_DU_CONFIG* config, _DU_ARGV* args){
 
     #ifdef DEBUG
     de_printout_single_token(par.token);
-    de_printout_single_token(parser_next(&par));
-    de_printout_single_token(parser_next(&par));
-    de_printout_single_token(parser_next(&par));
-    de_printout_single_token(parser_next(&par));
     #endif
 
     return 0;
@@ -64,6 +60,8 @@ Du_Main(int argc, char **argv){
             .argc = argc,
             .argv = argv
     };
+
+
 
     return du_main_run(&args);
 }


### PR DESCRIPTION
Strings are not differentiated from identifiers and can be detected by the DONSUS_STRING kind, memory allocation has been optimised and the DONSUS_NUMBER detection problem has been resolved. 