### PR TITLE
a = a + 1 is possible now, as of now we can't process this as number …

### DIFF
--- a/Grammar/GRAMMAR.dong
+++ b/Grammar/GRAMMAR.dong
@@ -67,6 +67,7 @@ assignment_op:
                | DONSUS_MINUS_EQUAL
                | DONSUS_STAR_EQUAL
                | DONSUS_SLASH_EQUAL
+               | DONSUS_EQUAL # support a = a + 1, eg
 
 assignment_value:
     | assignment_start


### PR DESCRIPTION
As of now, we can parse expressions such as `a + 1`, this means that variable definitions or assignments can benefit from this feature. 

- Improve on the AST structure, right now our compiler can't comprehend operators between tokens.

`a + 1` -> here the `+` operator would be ignored.