### PR TITLE
Resolve num_expr, convert`global_node`, allow assignments like `a = a+4/5`, improve print system

### DIFF
--- a/Include/parser.h
+++ b/Include/parser.h
@@ -58,7 +58,12 @@ public:
 
   // create node
   // parsing expression
-  auto donsus_expr() -> parse_result;
+  auto donsus_expr(int ptp) -> parse_result;
+  auto match_expressions(int ptp) -> parse_result;
+  auto create_expression(donsus_ast::donsus_node_type type,
+                         u_int64_t child_count) -> parse_result;
+  auto make_new_expr_node(donsus_token prev_token, parse_result &left,
+                          parse_result &right) -> parse_result;
   // parsing number expressions
   auto donsus_number_expr(unsigned int ptp) -> parse_result;
   auto donsus_number_primary(donsus_ast::donsus_node_type type,
@@ -108,6 +113,7 @@ public:
   auto create_identifier(donsus_ast::donsus_node_type type,
                          u_int64_t child_count) -> parse_result;
 
+  // this is only for number expressions
   auto make_new_num_node(donsus_token prev_token, parse_result &left,
                          parse_result &right) -> parse_result;
   donsus_token cur_token;

--- a/Include/parser.h
+++ b/Include/parser.h
@@ -107,6 +107,9 @@ public:
   auto donsus_identifier() -> parse_result;
   auto create_identifier(donsus_ast::donsus_node_type type,
                          u_int64_t child_count) -> parse_result;
+
+  auto make_new_num_node(donsus_token prev_token, parse_result &left,
+                         parse_result &right) -> parse_result;
   donsus_token cur_token;
   donsus_lexer lexer;
   utility::handle<donsus_ast::tree> donsus_tree; // holds top level ast nodes

--- a/src/ast/node.cc
+++ b/src/ast/node.cc
@@ -22,6 +22,8 @@ auto donsus_node_type::to_string() const -> std::string {
     return "DONSUS_IDENTIFIER";
   case DONSUS_IF_STATEMENT:
     return "DONSUS_IF_STATEMENT";
+  case DONSUS_EXPRESSION:
+    return "DONSUS_EXPRESSION";
   }
 }
 
@@ -51,6 +53,9 @@ donsus_ast::de_get_from_donsus_node_type(donsus_ast::donsus_node_type type) {
   }
   case donsus_node_type::DONSUS_ASSIGNMENT: {
     return "DONSUS_ASSIGNMENT";
+  }
+  case donsus_node_type::DONSUS_EXPRESSION: {
+    return "DONSUS_EXPRESSION";
   }
 
   default: {

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -21,7 +21,8 @@ struct donsus_node_type {
     DONSUS_IF_STATEMENT,         // just the type of the node
     DONSUS_ASSIGNMENT,           // just the type of the node
     DONSUS_IDENTIFIER,
-    DONSUS_NUMBER_EXPRESSION // just the type of the node
+    DONSUS_NUMBER_EXPRESSION, // just the type of the node
+    DONSUS_EXPRESSION
   };
 
   donsus_node_type() = default;
@@ -86,6 +87,10 @@ struct assignment {
 
 struct identifier {
   std::string identifier_name; //  name of lvalue
+};
+
+struct expression {
+  donsus_token value;
 };
 
 using node_properties =

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -323,14 +323,18 @@ void consume_spaces(DonsusParser &parser) {
       break;
     }
     case '/': {
-      eat(parser); // consume '*'
-      if (parser.lexer.cur_char == '*') {
+      if (peek_for_char(parser) == '*') {
+        eat(parser); // consume '*'
         eat(parser); // consume '/'
         while (parser.lexer.cur_char != '*' && peek_for_char(parser) != '/') {
           eat(parser); // get next token
         }
         eat(parser); // consume '/' after '*'
+        eat(parser); // consume '/' after '*'
         break;
+      } else {
+        // It's a divisor(DONSUS_SLASH) operator and not a comment
+        return;
       }
     default:
       return;
@@ -502,13 +506,10 @@ donsus_token donsus_lexer_next(DonsusParser &parser) {
       eat(parser);
 
       return cur_token;
-
-      return cur_token;
     }
   }
 
   case '/': {
-
     if (peek_for_char(parser) == '=') {
       cur_token.kind = DONSUS_SLASH_EQUAL;
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -287,15 +287,14 @@ auto DonsusParser::donsus_number_expr(unsigned int ptp) -> parse_result {
   donsus_parser_next();
 
   donsus_token previous_token = cur_token; // SAVE CUR_TOKEN
-  std::cout << "length of cur_token: " << cur_token.length << "\n";
+  //   std::cout << "length of cur_token: " << cur_token.length << "\n";
 
   if (cur_token.kind == DONSUS_SEMICOLON) { // CHECK END
     return left;                            // return whole node
   }
 
-  donsus_parser_next();
-
   while (previous_token.precedence > ptp) {
+    donsus_parser_next();
     right = donsus_number_expr(previous_token.precedence); // recursive call
     global_node = create_number_expression(
         donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION, 10);


### PR DESCRIPTION
- The `global_node` idea in number expressions has been gotten rid of and now as before we store everything on the `left` as we should(works properly now)
- Assignments can be parsed down thanks to `donsus_expr` which builds on top of the same logic as number expressions but it allows anything that is inside of `match_expressions`, as of now this only includes numbers and identifiers, but it can easily be extended by adding a new case inside of `match_expressions`. 
- Regarding the print system different children are now separated by space preventing any confusion, assignments and number expressions are now printed out properly and recursively with their children. (later I might develop something aesthetically better but this is fine for now)