### PR TITLE
unary expressions, booleans, extended typecheck

### DIFF
--- a/Include/parser.h
+++ b/Include/parser.h
@@ -97,9 +97,15 @@ public:
   auto create_string_expression(donsus_ast::donsus_node_type type,
                                 u_int64_t child_count) -> parse_result;
 
+  // parsing boolean expressions
   auto bool_expression() -> parse_result;
   auto create_bool_expression(donsus_ast::donsus_node_type type,
                               u_int64_t child_count) -> parse_result;
+
+  // parsing unary expressions
+  auto unary_expression() -> parse_result;
+  auto create_unary_expression(donsus_ast::donsus_node_type type,
+                               u_int64_t child_count) -> parse_result;
 
   // Function definition
   auto donsus_function_definition() -> parse_result;

--- a/donsus_test/CMakeLists.txt
+++ b/donsus_test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(donsus_test
         parser/test_return.cc
         parser/test_assignments.cc
         parser/test_print.cc
+        parser/test_unary_expressions.cc
 
         # typecheck
         typecheck/test_return.cc
@@ -32,6 +33,9 @@ add_executable(donsus_test
         typecheck/test_function_call_rvalue.cc
         typecheck/test_identifier_rvalue.cc
         typecheck/test_if_statements_type.cc
+        typecheck/test_unary_expressions_rvalue.cc
+        typecheck/test_bools.cc
+        
        
 
         #symbol table

--- a/donsus_test/parser/test_unary_expressions.cc
+++ b/donsus_test/parser/test_unary_expressions.cc
@@ -1,0 +1,15 @@
+#include "../Include/sema.h"
+#include <gtest/gtest.h>
+
+TEST(UnaryExpressionsRvalue, UnaryExpressionsCheck) {
+  std::string a = R"(
+        a:int = -5;
+    )";
+
+  DonsusParser::end_result result = Du_Parse(a);
+
+  donsus_ast::donsus_node_type::underlying type =
+      result->get_nodes()[0]->children[0]->type.type;
+
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_UNARY_EXPRESSION, type);
+}

--- a/donsus_test/typecheck/test_bools.cc
+++ b/donsus_test/typecheck/test_bools.cc
@@ -1,0 +1,42 @@
+
+#include "../Include/sema.h"
+#include <gtest/gtest.h>
+
+TEST(BooleanTypecheckAsExpressionsCorrect, BooleanTypecheck) {
+  std::string a = R"(
+        a:bool = false;
+        b:bool = true;
+    )";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+  EXPECT_NO_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); });
+}
+
+TEST(BooleanTypecheckAsExpressionsInCorrect, BooleanTypecheck) {
+  std::string a = R"(
+        a:int = true;
+    )";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}
+
+TEST(BooleanTypecheckAsExpressionsInCorrect2, BooleanTypecheck) {
+  std::string a = R"(
+        a:bool = 12;
+    )";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}

--- a/donsus_test/typecheck/test_unary_expressions_rvalue.cc
+++ b/donsus_test/typecheck/test_unary_expressions_rvalue.cc
@@ -1,0 +1,30 @@
+#include "../Include/sema.h"
+#include "../src/ast/tree.h"
+#include <gtest/gtest.h>
+
+TEST(UnaryExpressionsIncorrect, UnaryExpressionsTypecheck) {
+  std::string a = R"(
+    b:string = "12";
+    a:int = -b;
+)";
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+
+  parse_result->init_traverse();
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}
+
+TEST(UnaryExpressionsIncorrect, UnaryExpressionsTypecheckUnsigned) {
+  std::string a = R"(
+    a:u32 = -1;
+)";
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+
+  parse_result->init_traverse();
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      UnsignedTypeException);
+}

--- a/src/ast/node.cc
+++ b/src/ast/node.cc
@@ -32,6 +32,8 @@ auto donsus_node_type::to_string() const -> std::string {
     return "DONSUS_RETURN_STATEMENT";
   case DONSUS_STRING_EXPRESSION:
     return "DONSUS_STRING_EXPRESSION";
+  case DONSUS_UNARY_EXPRESSION:
+    return "DONSUS_UNARY_EXPRESSION";
   case DONSUS_BOOL_EXPRESSION:
     return "DONSUS_BOOL_EXPRESSION";
   case DONSUS_PRINT_EXPRESSION:
@@ -83,6 +85,10 @@ donsus_ast::de_get_from_donsus_node_type(donsus_ast::donsus_node_type type) {
   }
   case donsus_node_type::DONSUS_STRING_EXPRESSION: {
     return "DONSUS_STRING_EXPRESSION";
+  }
+
+  case donsus_node_type::DONSUS_UNARY_EXPRESSION: {
+    return "DONSUS_UNARY_EXPRESSION";
   }
 
   case donsus_node_type::DONSUS_BOOL_EXPRESSION: {

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -28,6 +28,7 @@ struct donsus_node_type {
     DONSUS_RETURN_STATEMENT,     // just the type of the node
     DONSUS_STRING_EXPRESSION,
     DONSUS_BOOL_EXPRESSION,
+    DONSUS_UNARY_EXPRESSION,
     DONSUS_PRINT_EXPRESSION
   };
 
@@ -56,6 +57,10 @@ struct number_expr {
 
 struct bool_expr {
   donsus_token value;
+};
+
+struct unary_expr {
+  donsus_token op;
 };
 
 // actual node structure containing extra properties

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -51,6 +51,13 @@ public:
       break;
     }
 
+    case type::DONSUS_UNARY_EXPRESSION: {
+      print_type(ast_node->type, indent_level);
+      print_with_newline("expression: ", indent_level);
+      print_ast_node(ast_node->children[0], indent_level + 1);
+      break;
+    }
+
     case type::DONSUS_PRINT_EXPRESSION: {
       print_type(ast_node->type, indent_level);
       indent_level++;
@@ -493,6 +500,7 @@ auto DonsusParser::match_expressions(int ptp) -> parse_result {
     return donsus_number_primary(
         donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION, 20);
   }
+
   case DONSUS_NAME: {
     if (donsus_peek().kind == DONSUS_LPAR) {
       return donsus_function_decl();
@@ -511,6 +519,10 @@ auto DonsusParser::match_expressions(int ptp) -> parse_result {
 
   case DONSUS_FALSE_KW: {
     return bool_expression();
+  }
+
+  case DONSUS_MINUS: {
+    return unary_expression();
   }
 
   default: {
@@ -963,6 +975,17 @@ auto DonsusParser::bool_expression() -> parse_result {
   return result;
 }
 
+auto DonsusParser::unary_expression() -> parse_result {
+  donsus_parser_next();
+  parse_result result = create_expression(
+      donsus_ast::donsus_node_type::DONSUS_UNARY_EXPRESSION, 10);
+  auto &expression = result->get<donsus_ast::unary_expr>();
+  expression.op = cur_token;
+  parse_result unary = donsus_expr(0);
+  result->children.push_back(unary);
+  return result;
+}
+
 auto DonsusParser::donsus_print() -> parse_result {
   parse_result print = create_donsus_print(
       donsus_ast::donsus_node_type::DONSUS_PRINT_EXPRESSION, 10);
@@ -1072,6 +1095,12 @@ auto DonsusParser::create_bool_expression(donsus_ast::donsus_node_type type,
                                           uint64_t child_count)
     -> parse_result {
   return donsus_tree->create_node<donsus_ast::bool_expr>(type, child_count);
+}
+
+auto DonsusParser::create_unary_expression(donsus_ast::donsus_node_type type,
+                                           uint64_t child_count)
+    -> parse_result {
+  return donsus_tree->create_node<donsus_ast::unary_expr>(type, child_count);
 }
 
 auto DonsusParser::create_donsus_print(donsus_ast::donsus_node_type type,

--- a/src/utility/exception.h
+++ b/src/utility/exception.h
@@ -45,4 +45,10 @@ public:
   DonsusUndefinedException(const std::string &message)
       : DonsusException(message) {}
 };
+class UnsignedTypeException : public DonsusException {
+public:
+  UnsignedTypeException() = default;
+  UnsignedTypeException(const std::string &message)
+      : DonsusException(message) {}
+};
 #endif


### PR DESCRIPTION
things like this work now: 
```
a:bool = true;
a:bool= false;
c:int = -5;
d:u32 = -10;  # will get errors accordingly 
```