### PR TITLE
solved setting `inst` for sym. basic assignment w/ identifiers

### DIFF
--- a/Include/symbol_table.h
+++ b/Include/symbol_table.h
@@ -102,6 +102,8 @@ public:
 
   auto get_global(std::string qualified_name) -> sym;
 
+  void setInst(std::string qualified_name, llvm::AllocaInst *inst);
+
   // for debugging purposes
   bool operator==(DonsusSymTable const &rhs) const {
     return underlying == rhs.underlying && sym_table == rhs.sym_table;

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -191,8 +191,7 @@ llvm::Value *DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
     // CreateAlloca (Type *Ty, Value *ArraySize=nullptr, const Twine &Name="")
     llvm::AllocaInst *Allocadef =
         Builder->CreateAlloca(map_type(make_type(type)), 0, name);
-    DonsusSymTable::sym sym_def = table->get(name);
-    sym_def.inst = Allocadef;
+    table->setInst(name, Allocadef);
     llvm::Value *def_value = compile(ast->children[0], table);
     Builder->CreateStore(def_value, Allocadef);
     llvm::Value *CurVardef =
@@ -203,8 +202,7 @@ llvm::Value *DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
   llvm::AllocaInst *Alloca =
       Builder->CreateAlloca(map_type(make_type(type)), 0, name);
 
-  DonsusSymTable::sym sym1 = table->get(name);
-  sym1.inst = Alloca;
+  table->setInst(name, Alloca);
   llvm::Value *decl_value =
       llvm::ConstantInt::get(*TheContext, llvm::APInt(32, 0));
   Builder->CreateStore(decl_value, Alloca);
@@ -406,9 +404,9 @@ DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
                            donsus_ast::bool_expr &ca_ast,
                            utility::handle<DonsusSymTable> &table) {
   if (ca_ast.value.value == "true")
-    return llvm::ConstantInt::get(*TheContext, llvm::APInt(32, 1, false));
+    return llvm::ConstantInt::get(*TheContext, llvm::APInt(8, 1, false));
 
-  return llvm::ConstantInt::get(*TheContext, llvm::APInt(32, 0, false));
+  return llvm::ConstantInt::get(*TheContext, llvm::APInt(8, 0, false));
 }
 
 llvm::Value *

--- a/src/symbol_table.cc
+++ b/src/symbol_table.cc
@@ -80,6 +80,15 @@ auto DonsusSymTable::get(std::string qualified_name) -> sym {
   return b;
 }
 
+auto DonsusSymTable::setInst(std::string qualified_name, llvm::AllocaInst *inst)
+    -> void {
+  for (auto &n : underlying) {
+    if (n.key == create_qualified_name(qualified_name)) {
+      n.inst = inst;
+    }
+  }
+}
+
 auto DonsusSymTable::get_global(std::string qualified_name) -> sym {
   sym a;
   int found = 0;


### PR DESCRIPTION
We can generate code for this now:
```
a_bool: bool = true;
c_bool: bool = a_bool;
```