### PR TITLE
Todos:

### DIFF
--- a/Include/codegen/codegen.h
+++ b/Include/codegen/codegen.h
@@ -130,6 +130,8 @@ public:
   llvm::Value *visit(utility::handle<donsus_ast::node> &ast,
                      donsus_ast::unary_expr &ca_ast,
                      utility::handle<DonsusSymTable> &table);
+  llvm::Value *printf_format(utility::handle<donsus_ast::node> node,
+                             std::string name);
 
   llvm::Type *map_type(DONSUS_TYPE type);
   // meta

--- a/Include/codegen/codegen.h
+++ b/Include/codegen/codegen.h
@@ -21,6 +21,12 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Host.h"
+// opt
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassBuilder.h"
+
 #include <memory>
 
 // Select platform
@@ -65,6 +71,9 @@ public:
   void Link() const;
 
   int create_object_file();
+
+  // run llvm's default optimisation pipeline
+  void default_optimisation();
 
   void create_entry_point();
 

--- a/Include/codegen/codegen.h
+++ b/Include/codegen/codegen.h
@@ -109,7 +109,7 @@ public:
                      utility::handle<DonsusSymTable> &table);
 
   llvm::Value *visit(utility::handle<donsus_ast::node> &ast,
-                    donsus_ast::return_kw &ca_ast,
+                     donsus_ast::return_kw &ca_ast,
                      utility::handle<DonsusSymTable> &table);
 
   llvm::Value *visit(donsus_ast::string_expr &ast,
@@ -132,7 +132,8 @@ public:
                      utility::handle<DonsusSymTable> &table);
 
   llvm::Type *map_type(DONSUS_TYPE type);
-
+  // meta
+  llvm::BasicBlock *main_block;
   std::unique_ptr<llvm::LLVMContext> TheContext;
   std::unique_ptr<llvm::IRBuilder<>> Builder;
   std::unique_ptr<llvm::Module> TheModule;

--- a/Include/symbol_table.h
+++ b/Include/symbol_table.h
@@ -16,11 +16,12 @@ public:
   std::vector<utility::handle<DonsusSymTable>> sym_table;
   std::string qa_sym = "global";
   std::vector<DONSUS_TYPE> function_return_type; // only for function def
+  utility::handle<DonsusSymTable> parent = nullptr; //
   struct sym {
     int mod;
     DONSUS_TYPE type;
     std::vector<DONSUS_TYPE> types; // if they are stored as a group
-    llvm::Value *inst;       // This can represent AllocaDef, or a function
+    llvm::Value *inst;       // This can represent AllocaDef, or a function as an lvalue
     bool duplicated = false; // true if its duplicated in the symbol_table
     std::size_t index;       // the order in which the addition happened
     std::string key;         // qualified_name
@@ -79,7 +80,7 @@ public:
   get_function_argument(int index);
 
   /*
-   * Applies the qualifed name to a pass name to compare
+   * Applies the qualified name to a pass name to compare
    */
 
   std::string apply_scope(std::string &name);
@@ -113,7 +114,8 @@ private:
   // create qualified name from short_name(private)
   std::string create_qualified_name(std::string &short_name);
 
-  // get the symbol based on the qualified name(private)
+  // get the symbol based on the qualified name(private), this will propagate
+  // to other symbol tables if the current one does not contain the one we need.
   auto get_from_qualified_name(std::string &qualified_name) -> sym;
   // holds underlying symbols(private)
   std::vector<sym> underlying;

--- a/Include/symbol_table.h
+++ b/Include/symbol_table.h
@@ -20,7 +20,7 @@ public:
     int mod;
     DONSUS_TYPE type;
     std::vector<DONSUS_TYPE> types; // if they are stored as a group
-    llvm::AllocaInst *inst;         // for codegen instruction
+    llvm::Value *inst;       // This can represent AllocaDef, or a function
     bool duplicated = false; // true if its duplicated in the symbol_table
     std::size_t index;       // the order in which the addition happened
     std::string key;         // qualified_name
@@ -100,7 +100,8 @@ public:
   // get symbol based on qualified name
   auto get(std::string qualified_name) -> sym;
 
-  void setInst(std::string qualified_name, llvm::AllocaInst *inst);
+  // set inst field from CreateAlloca or a function
+  void setInst(std::string qualified_name, llvm::Value *inst);
 
   // for debugging purposes
   bool operator==(DonsusSymTable const &rhs) const {

--- a/contrib/llvm_examples/void/CMakeLists.txt
+++ b/contrib/llvm_examples/void/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(d-llvm)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Find LLVM
+execute_process(COMMAND llvm-config --cmakedir OUTPUT_VARIABLE LLVM_CMAKE_DIR)
+string(STRIP ${LLVM_CMAKE_DIR} LLVM_CMAKE_DIR)
+list(APPEND CMAKE_PREFIX_PATH ${LLVM_CMAKE_DIR})
+find_package(LLVM REQUIRED CONFIG)
+
+# Set compiler options
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_COMPILE_FLAGS}")
+set(ENABLE_LLVM_SHARED 1)
+include_directories(${LLVM_INCLUDE_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+add_library(donsus_lib STATIC
+        main.cc
+)
+
+
+#[[add_compile_options(-fsanitize=address) # ASAN
+add_link_options(-fsanitize=address) # ASAN]]
+
+execute_process(COMMAND llvm-config --libs core irreader support OUTPUT_VARIABLE LLVM_LIBS)
+string(STRIP ${LLVM_LIBS} LLVM_LIBS)
+target_link_libraries(donsus_lib PUBLIC ${LLVM_LIBS})
+
+set(CMAKE_BUILD_TYPE Debug)
+
+add_executable(donsus main.cc)
+
+llvm_map_components_to_libnames(llvm_libs core irreader support)
+target_link_libraries(donsus PUBLIC ${llvm})
+target_link_libraries(donsus PUBLIC donsus_lib)
+

--- a/contrib/llvm_examples/void/main.cc
+++ b/contrib/llvm_examples/void/main.cc
@@ -1,0 +1,63 @@
+#include <llvm/IR/Function.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Constants.h>
+
+class CodeGen {
+public:
+  CodeGen() = default;
+  CodeGen(std::unique_ptr<llvm::LLVMContext> context,
+          std::unique_ptr<llvm::Module> module,
+          std::unique_ptr<llvm::IRBuilder<>> builder)
+      : TheContext(std::move(context)), TheModule(std::move(module)),
+        Builder(std::move(builder)) {
+    create_entry_point();
+  }
+
+  void create_entry_point() {
+    llvm::FunctionType *FT =
+        llvm::FunctionType::get(llvm::Type::getInt32Ty(*TheContext), false);
+    std::string name = "main";
+
+    llvm::Function *F = llvm::Function::Create(
+        FT, llvm::Function::ExternalLinkage, name, *TheModule);
+    llvm::BasicBlock *block = llvm::BasicBlock::Create(*TheContext, "entry", F);
+    Builder->SetInsertPoint(block);
+
+    // Actual instructions for main
+    Builder->CreateRet(llvm::ConstantInt::get(*TheContext, llvm::APInt(32, 0)));
+
+    // Creating "just_void" function
+    llvm::FunctionType* FT2 = llvm::FunctionType::get(llvm::Type::getVoidTy(*TheContext), false);
+    std::string name2 = "just_void";
+
+    llvm::Function *F1 = llvm::Function::Create(
+        FT2, llvm::Function::ExternalLinkage, name2, *TheModule
+    );
+
+    llvm::BasicBlock* block2 = llvm::BasicBlock::Create(*TheContext, "just_void", F1);
+
+    // Actual instructions for just_void
+    // call it
+    Builder->SetInsertPoint(block2);
+    Builder->CreateRetVoid();
+  }
+  std::unique_ptr<llvm::LLVMContext> TheContext;
+  std::unique_ptr<llvm::Module> TheModule;
+  std::unique_ptr<llvm::IRBuilder<>> Builder;
+};
+int main() {
+  std::unique_ptr<llvm::LLVMContext> TheContext =
+      std::make_unique<llvm::LLVMContext>();
+  std::unique_ptr<llvm::Module> TheModule =
+      std::make_unique<llvm::Module>("Donsus IR", *TheContext);
+  std::unique_ptr<llvm::IRBuilder<>> TheBuilder =
+      std::make_unique<llvm::IRBuilder<>>(*TheContext);
+
+  CodeGen codegen(std::move(TheContext), std::move(TheModule),
+                  std::move(TheBuilder));
+
+  llvm::errs() << *codegen.TheModule;
+  return 0;
+}

--- a/contrib/llvm_examples/void/void.cc
+++ b/contrib/llvm_examples/void/void.cc
@@ -1,0 +1,8 @@
+void test(){
+
+}
+
+int main(){
+  test();
+  return 0;
+}

--- a/contrib/llvm_examples/void/void.ll
+++ b/contrib/llvm_examples/void/void.ll
@@ -1,0 +1,9 @@
+define void @test(){
+entry:
+    ret void
+}
+define i32 @main() {
+entry:
+    call void @test();
+    ret i32 0
+}

--- a/donsus_test/parser/test_print.cc
+++ b/donsus_test/parser/test_print.cc
@@ -7,8 +7,9 @@
  * */
 TEST(TestPrintLiteral, TestPrintSystem) {
   std::string a = R"(
-        print("a");
+        printf("a");
     )";
   DonsusParser::end_result result = Du_Parse(a);
-  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_STRING_EXPRESSION, result->get_nodes()[0]->children[0]->type.type);
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_STRING_EXPRESSION,
+            result->get_nodes()[0]->children[0]->type.type);
 }

--- a/slodon/readme.md
+++ b/slodon/readme.md
@@ -1,1 +1,0 @@
-Low level code generator library for Donsus's backends.

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -497,8 +497,12 @@ DonsusCodeGenerator::printf_format(utility::handle<donsus_ast::node> node,
   case DONSUS_TYPE::TYPE_I64:
   case DONSUS_TYPE::TYPE_I16:
   case DONSUS_TYPE::TYPE_U32: {
-    auto format_name = name + "for_printf_string";
+    auto format_name = name + "_for_printf_string";
     return Builder->CreateGlobalString("%d", format_name);
+  }
+  case DONSUS_TYPE::TYPE_STRING: {
+    auto format_name = name + "_for_printf_string";
+    return Builder->CreateGlobalString("%s", format_name);
   }
   default: {
   }

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -71,7 +71,7 @@ void DonsusCodeGenerator::create_entry_point() {
 }
 
 int DonsusCodeGenerator::create_object_file() {
-  default_optimisation();
+  // default_optimisation();
   const auto TargetTriple = llvm::sys::getDefaultTargetTriple();
   TheModule->setTargetTriple(TargetTriple);
 
@@ -258,6 +258,7 @@ llvm::Value *DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
   // instead of putting them in the main, they should be created globals
   // properly
   if (is_global_sym(name, table)) {
+    // Todo: should create a global-var
     Builder->SetInsertPoint(main_block);
   }
 
@@ -403,10 +404,13 @@ DonsusCodeGenerator::visit(donsus_ast::function_def &ast,
   Builder->SetInsertPoint(block);
 
   // setup the struct members
-
   for (auto node : ast.body) {
     compile(node, table);
   }
+  /*  // setup parameters
+    for (auto node : ast.parameters) {
+      // compile them down
+    }*/
   return F;
 }
 

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -18,7 +18,7 @@ std::map<std::string, donsus_token_kind> DONSUS_KEYWORDS{
     {"elif", DONSUS_ELIF_KW},
     {"else", DONSUS_ELSE_KW},
     {"return", DONSUS_RETURN_KW},
-    {"print", DONSUS_PRINT_KW},
+    {"printf", DONSUS_PRINT_KW},
     {"true", DONSUS_TRUE_KW},
     {"false", DONSUS_FALSE_KW}};
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -388,34 +388,18 @@ auto DonsusParser::donsus_parse() -> end_result {
   *this = save;
 #endif
   while (cur_token.kind != DONSUS_END) {
-    // switch (cur_token.kind) {
-    // case DONSUS_NUMBER: {
-    //   parse_result result = donsus_number_expr(0);
-    //   donsus_tree->add_node(result);
-    // }
-    // case DONSUS_NAME: {
-    //   /*      case DONSUS_BOOL:
-    //         case DONSUS_VOID:
-    //         case DONSUS_STRING:
-    //         case DONSUS_BASIC_INT:
-    //         case DONSUS_I8:
-    //         case DONSUS_I16:
-    //         case DONSUS_I32:
-    //         case DONSUS_I64:
-    //         case DONSUS_U32:*/
-    //   /*case DONSUS_U64:*/
-    //   donsus_tree->add_node(donsus_variable_decl());
-    //   break;
-    // }
-    // default: {
-    // }
-    // }
     if (cur_token.kind == DONSUS_NAME) {
       if (donsus_peek().kind == DONSUS_LPAR) {
         parse_result result = donsus_function_decl();
         donsus_tree->add_node(result);
       } else if (donsus_peek().kind == DONSUS_COLO) {
         parse_result result = donsus_variable_decl();
+        donsus_tree->add_node(result);
+      } else if (donsus_peek().kind == DONSUS_PLUS_EQUAL ||
+                 donsus_peek().kind == DONSUS_MINUS_EQUAL ||
+                 donsus_peek().kind == DONSUS_SLASH_EQUAL ||
+                 donsus_peek().kind == DONSUS_STAR_EQUAL) {
+        parse_result result = donsus_assignments();
         donsus_tree->add_node(result);
       } else {
         throw DonsusException(
@@ -553,8 +537,7 @@ auto DonsusParser::donsus_expr(int ptp) -> parse_result {
   parse_result right;
 
   if (cur_token.kind == DONSUS_LPAR) {
-    // Handle open paranthesis
-    donsus_parser_next(); // Move past the open paranthesis
+    donsus_parser_next();
     left = donsus_expr(ptp);
   } else {
     try {

--- a/src/sema.cc
+++ b/src/sema.cc
@@ -1,45 +1,4 @@
-// Construct symbol table from ast(1)
-// Semantic analysis generates SEA OF NODES from symbol table(2) or AST(TBD)
-/* \*
- *    AST(no):
- *      +
- *     /  \
- *    2    3
- *
- *
- *      name     type    scope
- *     |-----------------------|
- *     |       |        |      |
- *     |-----------------------|
- *     |       |        |      |
- *     |-----------------------|
- *     |       |        |      |
- *     |-----------------------|
- *
- */
-/*
- Type checking TODOS:
-  - check if the number of return values matches the one in the function
- prototype
-  unsigned long int a = 12 + "sdfsd" + func_call();
-  - figure out if the if statement is true
-
-  -see whether parameters/arguments have the correct type.
-  - typecheck assignments
-
-DONSUS_EXPRESSION:
-  Call donsus_typecheck_support_between_types to see whether operators between
-operands are supported
-  - Assign type of DONSUS_EXPRESSION by assigning type to each of its nodes,
-  and then pick the closest one(from children - process_donsus_expression) to
-determine the expression type -Obtaining the type happens in
-donsus_typecheck_type_expr.
-  - Then just simply match it against the type defined in the variable
-definition a:int - here int is the type.
-  */
-
 #include "../Include/sema.h"
-#include <set>
 
 DonsusSema sema;
 auto assign_type_to_node(utility::handle<donsus_ast::node> node,
@@ -145,10 +104,10 @@ auto assign_type_to_node(utility::handle<donsus_ast::node> node,
 
   case donsus_ast::donsus_node_type::DONSUS_IDENTIFIER: {
     std::string iden_name = node->get<donsus_ast::identifier>().identifier_name;
-    bool is_exist_locally = sema.donsus_sema_is_exist(iden_name, table);
-    bool is_exist_globally = sema.donsus_sema_is_exist(iden_name, global_table);
-    if (!is_exist_locally && !is_exist_globally)
+    bool is_exist = sema.donsus_sema_is_exist(iden_name, table);
+    if (!is_exist)
       throw DonsusUndefinedException(iden_name + " is not defined");
+
     DonsusSymTable::sym identifier_symbol_local = table->get(iden_name);
     DonsusSymTable::sym identifier_symbol_global = global_table->get(iden_name);
 
@@ -189,17 +148,13 @@ void donsus_sym(utility::handle<donsus_ast::node> node,
    Call type checking function with the correct type
    **/
   switch (node->type.type) {
-
   case donsus_ast::donsus_node_type::DONSUS_VARIABLE_DECLARATION: {
     auto decl_name = node->get<donsus_ast::variable_decl>().identifier_name;
 
-    bool is_declared_locally = sema.donsus_sema_is_duplicated(
+    bool is_declared = sema.donsus_sema_is_duplicated(
         node->get<donsus_ast::variable_decl>().identifier_name, table);
 
-    bool is_declared_globally = sema.donsus_sema_is_duplicated(
-        node->get<donsus_ast::variable_decl>().identifier_name, global_table);
-
-    if (is_declared_locally || is_declared_globally)
+    if (is_declared)
       throw ReDefinitionException(decl_name + " has been already declared!");
     break;
   }
@@ -303,11 +258,9 @@ void donsus_sym(utility::handle<donsus_ast::node> node,
   case donsus_ast::donsus_node_type::DONSUS_ASSIGNMENT: {
     auto assignment_name = node->get<donsus_ast::assignment>().identifier_name;
 
-    bool is_defined_locally = sema.donsus_sema_is_exist(assignment_name, table);
-    bool is_defined_globally =
-        sema.donsus_sema_is_exist(assignment_name, global_table);
+    bool is_defined = sema.donsus_sema_is_exist(assignment_name, table);
 
-    if (!is_defined_locally && !is_defined_globally)
+    if (!is_defined)
       throw DonsusUndefinedException(assignment_name + " is not defined");
 
     assign_type_to_node(node->children[0], table, global_table);

--- a/src/symbol_table.cc
+++ b/src/symbol_table.cc
@@ -44,6 +44,7 @@ utility::handle<DonsusSymTable>
 DonsusSymTable::add_sym_table(std::string qa_sym_ex) {
   const utility::handle sym_ptr = allocator.r_alloc<DonsusSymTable>();
   sym_ptr->qa_sym = create_qualified_name(qa_sym_ex);
+  sym_ptr->parent = this;
   sym_table.push_back(sym_ptr);
   return sym_ptr;
 }
@@ -72,10 +73,19 @@ bool DonsusSymTable::is_sym_table_exist(
 }
 
 auto DonsusSymTable::get(std::string qualified_name) -> sym {
-  sym b = get_from_qualified_name(qualified_name);
-  if (b.mod == -1) {
-    // doesn't exist
-    return b; // empty
+  sym b;
+  b = get_from_qualified_name(qualified_name);
+  if (b.mod != -1){
+    return b;
+  }
+
+  while (parent) {
+      b = parent->get_from_qualified_name(qualified_name);
+    if (b.mod == -1 && parent->parent) {
+      parent = parent->parent;
+    } else {
+      return b;
+    }
   }
   return b;
 }

--- a/src/symbol_table.cc
+++ b/src/symbol_table.cc
@@ -80,7 +80,7 @@ auto DonsusSymTable::get(std::string qualified_name) -> sym {
   return b;
 }
 
-auto DonsusSymTable::setInst(std::string qualified_name, llvm::AllocaInst *inst)
+auto DonsusSymTable::setInst(std::string qualified_name, llvm::Value *inst)
     -> void {
   for (auto &n : underlying) {
     if (n.key == create_qualified_name(qualified_name)) {


### PR DESCRIPTION
Priorities:
```
- When a variable is defined outside of a function, we need to make it global -> llvm::Global
- We still need to add support for parameters/arguments as well as function calls
- Multiple return types
```