### PR TITLE
added array declaration/definition parsing & Typechecking arrays

### DIFF
--- a/Include/parser.h
+++ b/Include/parser.h
@@ -76,6 +76,16 @@ public:
   auto create_variable_declaration(donsus_ast::donsus_node_type type,
                                    u_int64_t child_count) -> parse_result;
 
+  // parsing array definition
+  auto donsus_array_definition(parse_result &declaration) -> parse_result;
+  auto create_array_definition(donsus_ast::donsus_node_type type,
+                               u_int64_t child_count) -> parse_result;
+
+  // parsing array declaration
+  auto donsus_array_declaration(parse_result &declaration) -> parse_result;
+  auto create_array_declaration(donsus_ast::donsus_node_type type,
+                                u_int64_t child_count) -> parse_result;
+
   // parsing variable definition
   auto donsus_variable_definition(parse_result &declaration) -> parse_result;
 

--- a/donsus_test/CMakeLists.txt
+++ b/donsus_test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(donsus_test
         parser/test_print.cc
         parser/test_unary_expressions.cc
         parser/test_float.cc
+        parser/test_arrays.cc
 
         # typecheck
         typecheck/test_return.cc
@@ -36,6 +37,7 @@ add_executable(donsus_test
         typecheck/test_if_statements_type.cc
         typecheck/test_unary_expressions_rvalue.cc
         typecheck/test_bools.cc
+        typecheck/test_arrays_typecheck.cc
         
        
 

--- a/donsus_test/parser/test_arrays.cc
+++ b/donsus_test/parser/test_arrays.cc
@@ -1,0 +1,33 @@
+#include "parser.h"
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+TEST(ArrayStructureTest, ArrayDefinitionTest) {
+  std::string a = R"(
+  a:int[] = [1, 2, 3];
+)";
+  DonsusParser::end_result result = Du_Parse(a);
+  // match array_def
+  auto array_def = result->get_nodes()[0]->type;
+  EXPECT_EQ(array_def.type,
+            donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION);
+
+  // match elements
+  auto elements = result->get_nodes()[0]->get<donsus_ast::array_def>().elements;
+  EXPECT_EQ(elements.size(), 3);
+  EXPECT_EQ(elements[0]->type.type,
+            donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION);
+}
+
+TEST(ArrayDeclaration, ArrayDeclarationTest) {
+  std::string a = R"(
+  a:int[];
+)";
+
+  DonsusParser::end_result result = Du_Parse(a);
+  // match array_decl
+  auto array_decl = result->get_nodes()[0]->type;
+  EXPECT_EQ(array_decl.type,
+            donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION);
+}

--- a/donsus_test/typecheck/test_arrays_typecheck.cc
+++ b/donsus_test/typecheck/test_arrays_typecheck.cc
@@ -1,0 +1,59 @@
+#include "../Include/sema.h"
+#include "../src/ast/tree.h"
+#include <gtest/gtest.h>
+
+TEST(ArrayTestTypecheckCorrect, ArrayTypeCheck) {
+  std::string a = R"(
+    a:int[] = [1, 2, 3];
+)";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_NO_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); });
+}
+
+TEST(ArrayTestTypecheckCorrect1, ArrayTypeCheck) {
+  std::string a = R"(
+    b:int = 12;
+    a:int[] = [1, 2, b];
+)";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_NO_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); });
+}
+
+TEST(ArrayTestTypecheckincorrect, ArrayTypeCheck) {
+  std::string a = R"(
+    b:string = "12";
+    a:int[] = [1, 2, b];
+)";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}
+
+TEST(ArrayTestTypecheckincorrect1, ArrayTypeCheck) {
+  std::string a = R"(
+    a:int[] = [1, 2, "12"];
+)";
+
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}

--- a/src/ast/node.cc
+++ b/src/ast/node.cc
@@ -38,7 +38,10 @@ auto donsus_node_type::to_string() const -> std::string {
     return "DONSUS_BOOL_EXPRESSION";
   case DONSUS_PRINT_EXPRESSION:
     return "DONSUS_PRINT_EXPRESSION";
-
+  case DONSUS_ARRAY_DECLARATION:
+    return "DONSUS_ARRAY_DECLARATION";
+  case DONSUS_ARRAY_DEFINITION:
+    return "DONSUS_ARRAY_DEFINITION";
   case DONSUS_FLOAT_EXPRESSION:
     return "DONSUS_FLOAT_EXPRESSION";
 
@@ -110,6 +113,14 @@ donsus_ast::de_get_from_donsus_node_type(donsus_ast::donsus_node_type type) {
 
   case donsus_node_type::DONSUS_FUNCTION_ARG: {
     return "DONSUS_FUNCTION_ARG";
+  }
+
+  case donsus_node_type::DONSUS_ARRAY_DECLARATION: {
+    return "DONSUS_ARRAY_DECLARATION";
+  }
+
+  case donsus_node_type::DONSUS_ARRAY_DEFINITION: {
+    return "DONSUS_ARRAY_DEFINITION";
   }
 
   default: {

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -27,7 +27,8 @@ struct donsus_node_type {
     DONSUS_FUNCTION_CALL,        // just the type of the node
     DONSUS_ELSE_STATEMENT,       // just the type of the node
     DONSUS_RETURN_STATEMENT,     // just the type of the node
-
+    DONSUS_ARRAY_DEFINITION,     // just the type of the node
+    DONSUS_ARRAY_DECLARATION,    // just the type of the node
     DONSUS_STRING_EXPRESSION,
     DONSUS_BOOL_EXPRESSION,
     DONSUS_UNARY_EXPRESSION,
@@ -59,8 +60,20 @@ struct number_expr {
   donsus_token value;
 };
 
-struct float_expr{
+struct float_expr {
   donsus_token value;
+};
+
+struct array_def {
+  std::string identifier_name;
+  donsus_token_kind type;
+  std::vector<utility::handle<donsus_ast::node>> elements;
+  int size;
+};
+
+struct array_decl {
+  std::string identifier_name;
+  donsus_token_kind type;
 };
 
 struct bool_expr {

--- a/src/ast/tree.cc
+++ b/src/ast/tree.cc
@@ -117,6 +117,20 @@ void tree::traverse_nodes(
     break;
   }
 
+  case donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION: {
+    auto stuff = n->get<donsus_ast::array_decl>();
+    sym->add(stuff.identifier_name,
+             make_type(n->get<donsus_ast::array_decl>().type));
+    break;
+  }
+
+  case donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION: {
+    auto stuff = n->get<donsus_ast::array_def>();
+    sym->add(stuff.identifier_name,
+             make_type(n->get<donsus_ast::array_def>().type));
+    break;
+  }
+
   case donsus_ast::donsus_node_type::DONSUS_ELSE_STATEMENT: {
     auto stuff = n->get<donsus_ast::else_statement>();
     for (auto &children : stuff.body) {


### PR DESCRIPTION
```
a:int[] = [1, 2, 3];
```
```
b:int = 2;
a:int[] = [1, 2, 3, b];
```
Errors are handled accordingly: 

```
b:string = "2";
a:int[] = [1, 2, 3, b]; # throw error here
```

