### PR TITLE
fixed, static, dynamic arrays can be parsed & comment issue fixed & rename size property, added ArrayType

### DIFF
--- a/Include/parser.h
+++ b/Include/parser.h
@@ -78,14 +78,14 @@ public:
 
   // parsing array definition
   auto donsus_array_definition(utility::handle<donsus_ast::node> &declaration,
-                               std::string array_type, int size)
+                               donsus_ast::ArrayType array_type, int size)
       -> parse_result;
   auto create_array_definition(donsus_ast::donsus_node_type type,
                                u_int64_t child_count) -> parse_result;
 
   // parsing array declaration
   auto donsus_array_declaration(utility::handle<donsus_ast::node> &declaration,
-                                std::string array_type, int size)
+                                donsus_ast::ArrayType array_type, int size)
       -> parse_result;
   auto create_array_declaration(donsus_ast::donsus_node_type type,
                                 u_int64_t child_count) -> parse_result;

--- a/Include/parser.h
+++ b/Include/parser.h
@@ -77,12 +77,16 @@ public:
                                    u_int64_t child_count) -> parse_result;
 
   // parsing array definition
-  auto donsus_array_definition(parse_result &declaration) -> parse_result;
+  auto donsus_array_definition(utility::handle<donsus_ast::node> &declaration,
+                               std::string array_type, int size)
+      -> parse_result;
   auto create_array_definition(donsus_ast::donsus_node_type type,
                                u_int64_t child_count) -> parse_result;
 
   // parsing array declaration
-  auto donsus_array_declaration(parse_result &declaration) -> parse_result;
+  auto donsus_array_declaration(utility::handle<donsus_ast::node> &declaration,
+                                std::string array_type, int size)
+      -> parse_result;
   auto create_array_declaration(donsus_ast::donsus_node_type type,
                                 u_int64_t child_count) -> parse_result;
 

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -65,6 +65,7 @@ struct float_expr {
 };
 
 struct array_def {
+  std::string array_type;
   std::string identifier_name;
   donsus_token_kind type;
   std::vector<utility::handle<donsus_ast::node>> elements;
@@ -72,6 +73,7 @@ struct array_def {
 };
 
 struct array_decl {
+  std::string array_type;
   std::string identifier_name;
   donsus_token_kind type;
 };

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -64,18 +64,33 @@ struct float_expr {
   donsus_token value;
 };
 
+enum ArrayType {
+  FIXED,  // fixed size array a:int[3] = [1,2,3];
+  STATIC, // static size array a:int[]. = [1,2,3];
+  DYNAMIC // dynamic size array a:int[] = [1,2,3];
+};
+
 struct array_def {
-  std::string array_type;
+  ArrayType array_type; // the type of the array either
   std::string identifier_name;
   donsus_token_kind type;
   std::vector<utility::handle<donsus_ast::node>> elements;
-  int size;
+  /*If the array_type is dynamic the size will be zero and ignored
+    If the array_type is static then the size must be provided
+  */
+  int size; // Represents the number between the square brackets a:int[3] =
+            // [1,2,3]; here it is 3
 };
 
 struct array_decl {
-  std::string array_type;
+  ArrayType array_type;
   std::string identifier_name;
   donsus_token_kind type;
+  /*If the array_type is dynamic the size will be zero and ignored
+    If the array_type is static then the size must be provided
+  */
+  int size; // Represents the number between the square brackets a:int[3] =
+            // [1,2,3]; here it is 3
 };
 
 struct bool_expr {

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -369,11 +369,14 @@ void consume_spaces(DonsusParser &parser) {
       if (peek_for_char(parser) == '*') {
         eat(parser); // consume '*'
         eat(parser); // consume '/'
-        while (parser.lexer.cur_char != '*' && peek_for_char(parser) != '/') {
+        while (parser.lexer.cur_char != '*') {
           eat(parser); // get next token
         }
-        eat(parser); // consume '/' after '*'
-        eat(parser); // consume '/' after '*'
+        if (peek_for_char(parser) == '/') {
+          eat(parser); // consume '/' after '*'
+          eat(parser); // consume '/' after '*'
+        }
+
         break;
       } else {
         // It's a divisor(DONSUS_SLASH) operator and not a comment

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -701,9 +701,11 @@ auto DonsusParser::donsus_variable_decl() -> parse_result {
         donsus_parser_next(); // move to '=' or ';'
         // check if its an array declaration or definition
         if (cur_token.kind == DONSUS_EQUAL) {
-          return donsus_array_definition(declaration, "DYNAMIC", 0);
+          return donsus_array_definition(declaration,
+                                         donsus_ast::ArrayType::DYNAMIC, 0);
         } else if (cur_token.kind == DONSUS_SEMICOLON) {
-          return donsus_array_declaration(declaration, "DYNAMIC", 0);
+          return donsus_array_declaration(declaration,
+                                          donsus_ast::ArrayType::DYNAMIC, 0);
         }
       } else if (donsus_peek().kind == DONSUS_NUMBER) {
         // fixed size array
@@ -716,15 +718,19 @@ auto DonsusParser::donsus_variable_decl() -> parse_result {
         if (cur_token.kind == DONSUS_DOT) {
           donsus_parser_next(); // move to the next token
           if (cur_token.kind == DONSUS_EQUAL) {
-            return donsus_array_definition(declaration, "STATIC", size);
+            return donsus_array_definition(declaration,
+                                           donsus_ast::ArrayType::STATIC, size);
           } else if (cur_token.kind == DONSUS_SEMICOLON) {
-            return donsus_array_declaration(declaration, "STATIC", size);
+            return donsus_array_declaration(
+                declaration, donsus_ast::ArrayType::STATIC, size);
           }
         }
         if (cur_token.kind == DONSUS_EQUAL) {
-          return donsus_array_definition(declaration, "FIXED", size);
+          return donsus_array_definition(declaration,
+                                         donsus_ast::ArrayType::FIXED, size);
         } else if (cur_token.kind == DONSUS_SEMICOLON) {
-          return donsus_array_declaration(declaration, "FIXED", size);
+          return donsus_array_declaration(declaration,
+                                          donsus_ast::ArrayType::FIXED, size);
         }
       }
       // // array
@@ -744,8 +750,8 @@ auto DonsusParser::donsus_variable_decl() -> parse_result {
 }
 
 auto DonsusParser::donsus_array_declaration(
-    utility::handle<donsus_ast::node> &declaration, std::string array_type,
-    int size = 0) -> parse_result {
+    utility::handle<donsus_ast::node> &declaration,
+    donsus_ast::ArrayType array_type, int size = 0) -> parse_result {
   // move to the next token
   parse_result array_declaration = create_array_declaration(
       donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION, 10);
@@ -761,8 +767,8 @@ auto DonsusParser::donsus_array_declaration(
 }
 
 auto DonsusParser::donsus_array_definition(
-    utility::handle<donsus_ast::node> &declaration, std::string array_type,
-    int size = 0) -> parse_result {
+    utility::handle<donsus_ast::node> &declaration,
+    donsus_ast::ArrayType array_type, int size = 0) -> parse_result {
   // move to the next token
   parse_result array_definition = create_array_definition(
       donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION, 10);
@@ -783,7 +789,6 @@ auto DonsusParser::donsus_array_definition(
     while (cur_token.kind != DONSUS_RSQB) {
       parse_result element = donsus_expr(0);
       expression.elements.push_back(element);
-      expression.size++;
       if (cur_token.kind == DONSUS_COMM) {
         donsus_parser_next();
       }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -691,18 +691,45 @@ auto DonsusParser::donsus_variable_decl() -> parse_result {
           DONSUS_VARIABLE_DEFINITION; // overwrite//
                                       // type
       return donsus_variable_definition(declaration);
-    } else if (donsus_peek().kind == DONSUS_LSQB &&
-               donsus_peek(2).kind == DONSUS_RSQB) {
+    } else if (donsus_peek().kind == DONSUS_LSQB) {
+
       // array
       donsus_parser_next(); // move to '['
-      donsus_parser_next(); // move to ']'
-      donsus_parser_next(); // move to '=' or ';'
-      // check if its an array declaration or definition
-      if (cur_token.kind == DONSUS_EQUAL) {
-        return donsus_array_definition(declaration);
-      } else if (cur_token.kind == DONSUS_SEMICOLON) {
-        return donsus_array_declaration(declaration);
+      if (donsus_peek().kind == DONSUS_RSQB) {
+        // dynamic array
+        donsus_parser_next(); // move to ']'
+        donsus_parser_next(); // move to '=' or ';'
+        // check if its an array declaration or definition
+        if (cur_token.kind == DONSUS_EQUAL) {
+          return donsus_array_definition(declaration, "DYNAMIC", 0);
+        } else if (cur_token.kind == DONSUS_SEMICOLON) {
+          return donsus_array_declaration(declaration, "DYNAMIC", 0);
+        }
+      } else if (donsus_peek().kind == DONSUS_NUMBER) {
+        // fixed size array
+
+        donsus_parser_next(); // move to the number
+        int size = std::stoi(cur_token.value);
+        donsus_parser_next(); // move to ']'
+        donsus_parser_next(); // move to '=' or ';' or .
+                              // check if its an array declaration or definition
+        if (cur_token.kind == DONSUS_DOT) {
+          donsus_parser_next(); // move to the next token
+          if (cur_token.kind == DONSUS_EQUAL) {
+            return donsus_array_definition(declaration, "STATIC", size);
+          } else if (cur_token.kind == DONSUS_SEMICOLON) {
+            return donsus_array_declaration(declaration, "STATIC", size);
+          }
+        }
+        if (cur_token.kind == DONSUS_EQUAL) {
+          return donsus_array_definition(declaration, "FIXED", size);
+        } else if (cur_token.kind == DONSUS_SEMICOLON) {
+          return donsus_array_declaration(declaration, "FIXED", size);
+        }
       }
+      // // array
+      // donsus_parser_next(); // move to '['
+
     } else {
       // decl only
       if (donsus_peek().kind == DONSUS_SEMICOLON) {
@@ -717,7 +744,8 @@ auto DonsusParser::donsus_variable_decl() -> parse_result {
 }
 
 auto DonsusParser::donsus_array_declaration(
-    utility::handle<donsus_ast::node> &declaration) -> parse_result {
+    utility::handle<donsus_ast::node> &declaration, std::string array_type,
+    int size = 0) -> parse_result {
   // move to the next token
   parse_result array_declaration = create_array_declaration(
       donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION, 10);
@@ -727,11 +755,14 @@ auto DonsusParser::donsus_array_declaration(
       declaration->get<donsus_ast::variable_decl>().identifier_name;
   expression.type =
       declaration->get<donsus_ast::variable_decl>().identifier_type;
+  expression.array_type = array_type;
+
   return array_declaration;
 }
 
 auto DonsusParser::donsus_array_definition(
-    utility::handle<donsus_ast::node> &declaration) -> parse_result {
+    utility::handle<donsus_ast::node> &declaration, std::string array_type,
+    int size = 0) -> parse_result {
   // move to the next token
   parse_result array_definition = create_array_definition(
       donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION, 10);
@@ -742,13 +773,28 @@ auto DonsusParser::donsus_array_definition(
   expression.type =
       declaration->get<donsus_ast::variable_decl>().identifier_type;
 
+  expression.array_type = array_type;
+
+  expression.size = size;
+
   donsus_parser_except(DONSUS_LSQB); // expect next token to be '['
   donsus_parser_next();              // move to the next token
-  while (cur_token.kind != DONSUS_RSQB) {
-    parse_result element = donsus_expr(0);
-    expression.elements.push_back(element);
-    if (cur_token.kind == DONSUS_COMM) {
-      donsus_parser_next();
+  if (expression.size == 0) {
+    while (cur_token.kind != DONSUS_RSQB) {
+      parse_result element = donsus_expr(0);
+      expression.elements.push_back(element);
+      expression.size++;
+      if (cur_token.kind == DONSUS_COMM) {
+        donsus_parser_next();
+      }
+    }
+  } else {
+    while (cur_token.kind != DONSUS_RSQB) {
+      parse_result element = donsus_expr(0);
+      expression.elements.push_back(element);
+      if (cur_token.kind == DONSUS_COMM) {
+        donsus_parser_next();
+      }
     }
   }
 


### PR DESCRIPTION
The distinction between static, fixed, and dynamic arrays is now present. The comment issue has been resolved. 