### PR TITLE
array access parsing & typecheck

### DIFF
--- a/Include/parser.h
+++ b/Include/parser.h
@@ -114,6 +114,11 @@ public:
   auto create_function_decl(donsus_ast::donsus_node_type type,
                             u_int64_t child_count) -> parse_result;
 
+  // Array access
+  auto donsus_array_access() -> parse_result;
+  auto create_array_access(donsus_ast::donsus_node_type type,
+                           u_int64_t child_count) -> parse_result;
+
   // parsing string expressions
   auto string_expression() -> parse_result;
   auto create_string_expression(donsus_ast::donsus_node_type type,

--- a/Include/symbol_table.h
+++ b/Include/symbol_table.h
@@ -92,6 +92,9 @@ public:
 
   std::string add(std::string short_name, DONSUS_TYPE type,
                   bool is_function_argument);
+
+  std::string add(std::string short_name_c, DONSUS_TYPE type,
+                  unsigned int num_of_elems, DONSUS_TYPE array_type);
   /*
    * Add symbol table to global.
    * */

--- a/donsus_test/parser/test_arrays.cc
+++ b/donsus_test/parser/test_arrays.cc
@@ -46,5 +46,22 @@ TEST(ArrayAcess, TestArrays) {
   EXPECT_EQ(result->get_nodes()[1]->children[0]->type.type,
             donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS);
   EXPECT_EQ(array_acess.identifier_name, "a");
-  EXPECT_EQ(array_acess.index, 0);
+}
+
+TEST(ArrayAcessExpressionAsIndex, TestArrays) {
+  std::string a = R"(
+  a:int[] = [0];
+
+  b:int = a[0 + 0];
+)";
+
+  DonsusParser::end_result result = Du_Parse(a);
+  // match array_decl
+  auto array_acess =
+      result->get_nodes()[1]->children[0]->get<donsus_ast::array_access>();
+  EXPECT_EQ(result->get_nodes()[1]->children[0]->type.type,
+            donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS);
+  EXPECT_EQ(array_acess.identifier_name, "a");
+  EXPECT_EQ(array_acess.index->type.type,
+            donsus_ast::donsus_node_type::DONSUS_EXPRESSION);
 }

--- a/donsus_test/parser/test_arrays.cc
+++ b/donsus_test/parser/test_arrays.cc
@@ -31,3 +31,20 @@ TEST(ArrayDeclaration, ArrayDeclarationTest) {
   EXPECT_EQ(array_decl.type,
             donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION);
 }
+
+TEST(ArrayAcess, TestArrays) {
+  std::string a = R"(
+  a:int[] = [0];
+
+  b:int = a[0];
+)";
+
+  DonsusParser::end_result result = Du_Parse(a);
+  // match array_decl
+  auto array_acess =
+      result->get_nodes()[1]->children[0]->get<donsus_ast::array_access>();
+  EXPECT_EQ(result->get_nodes()[1]->children[0]->type.type,
+            donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS);
+  EXPECT_EQ(array_acess.identifier_name, "a");
+  EXPECT_EQ(array_acess.index, 0);
+}

--- a/donsus_test/typecheck/test_arrays_typecheck.cc
+++ b/donsus_test/typecheck/test_arrays_typecheck.cc
@@ -69,3 +69,32 @@ TEST(ArrayOutOfBounds, ArrayTypeCheck) {
       { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
       OutOfBoundException);
 }
+
+TEST(ArrayAccessIncorrect, ArrayTypeCheck) {
+  std::string a = R"(
+    a:string[] = ["string"];
+
+    b:int = a[0];
+)";
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); },
+      InCompatibleTypeException);
+}
+
+TEST(ArrayAccessCorrect, ArrayTypeCheck) {
+  std::string a = R"(
+    a:int[] = [0];
+
+    b:int = a[0];
+)";
+  DonsusParser::end_result parse_result = Du_Parse(a);
+  utility::handle<DonsusSymTable> sym_global = new DonsusSymTable();
+  parse_result->init_traverse();
+
+  EXPECT_NO_THROW(
+      { parse_result->traverse(donsus_sym, assign_type_to_node, sym_global); });
+}

--- a/src/ast/node.cc
+++ b/src/ast/node.cc
@@ -49,6 +49,8 @@ auto donsus_node_type::to_string() const -> std::string {
     return "DONSUS_ARRAY_DEFINITION";
   case DONSUS_FLOAT_EXPRESSION:
     return "DONSUS_FLOAT_EXPRESSION";
+  case DONSUS_ARRAY_ACCESS:
+    return "DONSUS_ARRAY_ACCESS";
 
   case DONSUS_FUNCTION_ARG:
     return "DONSUS_FUNCTION_ARG";
@@ -126,6 +128,10 @@ donsus_ast::de_get_from_donsus_node_type(donsus_ast::donsus_node_type type) {
 
   case donsus_node_type::DONSUS_ARRAY_DEFINITION: {
     return "DONSUS_ARRAY_DEFINITION";
+  }
+
+  case donsus_node_type::DONSUS_ARRAY_ACCESS: {
+    return "DONSUS_ARRAY_ACCESS";
   }
 
   default: {

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -34,6 +34,7 @@ struct donsus_node_type {
     DONSUS_BOOL_EXPRESSION,
     DONSUS_UNARY_EXPRESSION,
     DONSUS_PRINT_EXPRESSION,
+    DONSUS_ARRAY_ACCESS,
     DONSUS_FUNCTION_ARG
 
   };
@@ -96,6 +97,11 @@ struct array_decl {
   int number_of_elements;
   int size; // Represents the number between the square brackets a:int[3] =
             // [1,2,3]; here it is 3
+};
+
+struct array_access {
+  std::string identifier_name;
+  int index;
 };
 
 struct bool_expr {
@@ -179,8 +185,7 @@ struct expression {
 
 struct print_expr {};
 
-using node_properties =
-    utility::property<>;
+using node_properties = utility::property<>;
 
 struct node : node_properties {
   //  // children tbd

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -101,7 +101,7 @@ struct array_decl {
 
 struct array_access {
   std::string identifier_name;
-  int index;
+  utility::handle<donsus_ast::node> index;
 };
 
 struct bool_expr {

--- a/src/ast/tree.cc
+++ b/src/ast/tree.cc
@@ -125,14 +125,20 @@ void tree::traverse_nodes(
   case donsus_ast::donsus_node_type::DONSUS_ARRAY_DECLARATION: {
     auto stuff = n->get<donsus_ast::array_decl>();
     sym->add(stuff.identifier_name,
-             make_type_array(n->get<donsus_ast::array_decl>().array_type));
+             make_type_array(n->get<donsus_ast::array_def>().array_type),
+             stuff.number_of_elements,
+             make_type(n->get<donsus_ast::array_def>().type));
+
     break;
   }
 
   case donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION: {
     auto stuff = n->get<donsus_ast::array_def>();
     sym->add(stuff.identifier_name,
-             make_type_array(n->get<donsus_ast::array_def>().array_type));
+             make_type_array(n->get<donsus_ast::array_def>().array_type),
+             stuff.number_of_elements,
+             make_type(n->get<donsus_ast::array_def>().type));
+
     break;
   }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -205,10 +205,8 @@ public:
           "identifier_name: " +
               ast_node->get<donsus_ast::array_access>().identifier_name,
           indent_level);
-      print_with_newline(
-          "index: " +
-              std::to_string(ast_node->get<donsus_ast::array_access>().index),
-          indent_level);
+      print_ast_node(ast_node->get<donsus_ast::array_access>().index,
+                     indent_level);
       break;
     }
 
@@ -632,7 +630,9 @@ auto DonsusParser::donsus_array_access() -> parse_result {
 
   donsus_parser_next(); // move to '['
   donsus_parser_next(); // move to the index
-  expression.index = std::stoi(cur_token.value);
+  // parse down index as expression
+  auto index_expression = donsus_expr(0);
+  expression.index = index_expression;
 
   donsus_parser_next(); // move to ']'
   return node;
@@ -664,8 +664,7 @@ auto DonsusParser::match_expressions(unsigned int ptp) -> parse_result {
   case DONSUS_NAME: {
     if (donsus_peek().kind == DONSUS_LPAR) {
       return donsus_function_decl();
-    } else if (donsus_peek().kind == DONSUS_LSQB &&
-               donsus_peek(3).kind == DONSUS_RSQB) {
+    } else if (donsus_peek().kind == DONSUS_LSQB) {
       return donsus_array_access();
     } else {
       return donsus_identifier();

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -199,6 +199,19 @@ public:
       break;
     }
 
+    case type::DONSUS_ARRAY_ACCESS: {
+      print_type(ast_node->type, indent_level);
+      print_with_newline(
+          "identifier_name: " +
+              ast_node->get<donsus_ast::array_access>().identifier_name,
+          indent_level);
+      print_with_newline(
+          "index: " +
+              std::to_string(ast_node->get<donsus_ast::array_access>().index),
+          indent_level);
+      break;
+    }
+
     case type::DONSUS_RETURN_STATEMENT: {
       print_type(ast_node->type, indent_level);
       if (ast_node->children.empty()) {
@@ -611,6 +624,20 @@ auto DonsusParser::donsus_float_number(donsus_ast::donsus_node_type type,
   return node;
 }
 
+auto DonsusParser::donsus_array_access() -> parse_result {
+  parse_result node = create_array_access(
+      donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS, 10);
+  auto &expression = node->get<donsus_ast::array_access>();
+  expression.identifier_name = cur_token.value;
+
+  donsus_parser_next(); // move to '['
+  donsus_parser_next(); // move to the index
+  expression.index = std::stoi(cur_token.value);
+
+  donsus_parser_next(); // move to ']'
+  return node;
+}
+
 // r-value expressions
 /*
 assignment_value:
@@ -637,6 +664,9 @@ auto DonsusParser::match_expressions(unsigned int ptp) -> parse_result {
   case DONSUS_NAME: {
     if (donsus_peek().kind == DONSUS_LPAR) {
       return donsus_function_decl();
+    } else if (donsus_peek().kind == DONSUS_LSQB &&
+               donsus_peek(3).kind == DONSUS_RSQB) {
+      return donsus_array_access();
     } else {
       return donsus_identifier();
     }
@@ -1390,6 +1420,11 @@ auto DonsusParser::create_return_statement(donsus_ast::donsus_node_type type,
     -> parse_result {
 
   return donsus_tree->create_node<donsus_ast::return_kw>(type, child_count);
+}
+
+auto DonsusParser::create_array_access(donsus_ast::donsus_node_type type,
+                                       u_int64_t child_count) -> parse_result {
+  return donsus_tree->create_node<donsus_ast::array_access>(type, child_count);
 }
 
 auto DonsusParser::create_identifier(donsus_ast::donsus_node_type type,

--- a/src/sema.cc
+++ b/src/sema.cc
@@ -54,6 +54,23 @@ auto assign_type_to_node(utility::handle<donsus_ast::node> node,
     break;
   }
 
+  case donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS: {
+    // make sure the array is defined
+    // make sure the index is correct
+    // assign the type based on the array
+
+    std::string array_name =
+        node->get<donsus_ast::array_access>().identifier_name;
+    bool is_exist = sema.donsus_sema_is_exist(array_name, table);
+    bool is_exist_global = sema.donsus_sema_is_exist(array_name, global_table);
+    if (!is_exist && !is_exist_global)
+      throw DonsusUndefinedException(array_name + " is not defined");
+
+    DONSUS_TYPE array_type = table->get(array_name).array.type;
+    node->real_type = array_type;
+    break;
+  }
+
   case donsus_ast::donsus_node_type::DONSUS_ARRAY_DEFINITION: {
     for (auto &n : node->get<donsus_ast::array_def>().elements) {
       assign_type_to_node(n, table, global_table);

--- a/src/symbol_table.cc
+++ b/src/symbol_table.cc
@@ -28,6 +28,32 @@ std::string DonsusSymTable::add(std::string short_name_c, DONSUS_TYPE type) {
   return qualified_name;
 }
 
+std::string DonsusSymTable::add(std::string short_name_c, DONSUS_TYPE type,
+                                unsigned int num_of_elems,
+                                DONSUS_TYPE array_type) {
+  /*
+   * add a minimal version of the symbol to the symbol table, this is only for
+   * arrays
+   * */
+  auto qualified_name = create_qualified_name(short_name_c);
+  // mymodule.short_name
+  sym t_symbol = {
+      .array =
+          {
+              .num_of_elems = num_of_elems,
+              .type = array_type,
+          },
+      .type = type,
+      .index = underlying.size(),
+      .key = qualified_name,
+      .short_name = short_name_c,
+      .kind = sym::SYMBOL_PLACEHOLDER,
+  };
+
+  underlying.push_back(t_symbol);
+  return qualified_name;
+}
+
 std::string DonsusSymTable::add(std::string short_name_c,
                                 std::vector<DONSUS_TYPE> &types) {
   auto qualified_name = create_qualified_name(short_name);


### PR DESCRIPTION
```
a:int[] = [0];
b:int = a[0]; # can be used as an expression
```

- type check and errors are implemented when it's used incorrectly. 

