### PR TITLE
rewritten assignments to be compatible with all of the expressions

### DIFF
--- a/donsus_test/parser/test_assignments.cc
+++ b/donsus_test/parser/test_assignments.cc
@@ -7,54 +7,41 @@
  * */
 TEST(AssignmentName, AssignmentName) {
   std::string a = R"(
-  def a() -> void{
-  a = a + 1;
-    }
+    a:int = 12;
+    a = 11;
 )";
   DonsusParser::end_result result = Du_Parse(a);
-  // std::string identifier_name = result->get_nodes()[0]
-  //                                   ->get<donsus_ast::function_def>()
-  //                                   .body[0]
-  //                                   ->get<donsus_ast::assignment>()
-  //                                   .identifier_name;
-
-  EXPECT_EQ("a", "");
+  // get the lvalue node of the assignment
+  utility::handle<donsus_ast::node> lvalue =
+      result->get_nodes()[1]->get<donsus_ast::assignment>().lvalue;
+  // get the name of the rvalue node
+  utility::handle<donsus_ast::node> rvalue =
+      result->get_nodes()[1]->get<donsus_ast::assignment>().rvalue;
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_IDENTIFIER, lvalue->type.type);
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION,
+            rvalue->type.type);
+  EXPECT_EQ(donsus_token_kind::DONSUS_EQUAL,
+            result->get_nodes()[1]->get<donsus_ast::assignment>().op.kind);
 }
 
-/** \brief Check for assignment's operator
- * */
-TEST(AssignmentOperator, AssignmentsTest) {
+TEST(AssignmentArrayAccess, AssignmentTest) {
   std::string a = R"(
-  def a() -> void{
-  a = a + 1;
-    }
+    a:int[] = [12, 11];
+    a[0] = 10;  
 )";
+
   DonsusParser::end_result result = Du_Parse(a);
-  donsus_token op = result->get_nodes()[0]
-                        ->get<donsus_ast::function_def>()
-                        .body[0]
-                        ->get<donsus_ast::assignment>()
-                        .op;
-
-  EXPECT_EQ(DONSUS_EQUAL, op.kind);
-}
-
-/** \brief Check for assignment value's type
- * */
-TEST(AssignmentValueType, AssignmentsTest) {
-  std::string a = R"(
-  def a() -> void{
-  a = a + 1;
-    }
-)";
-  DonsusParser::end_result result = Du_Parse(a);
-  donsus_ast::donsus_node_type::underlying assignment_value_type =
-      result->get_nodes()[0]
-          ->get<donsus_ast::function_def>()
-          .body[0]
-          ->children[0]
-          ->type.type;
-
-  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_EXPRESSION,
-            assignment_value_type);
+  // get the lvalue node of the assignment
+  utility::handle<donsus_ast::node> lvalue =
+      result->get_nodes()[1]->get<donsus_ast::assignment>().lvalue;
+  // get the name of the rvalue node
+  utility::handle<donsus_ast::node> rvalue =
+      result->get_nodes()[1]->get<donsus_ast::assignment>().rvalue;
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_ARRAY_ACCESS,
+            lvalue->type.type);
+  EXPECT_EQ("a", lvalue->get<donsus_ast::array_access>().identifier_name);
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION,
+            lvalue->get<donsus_ast::array_access>().index->type.type);
+  EXPECT_EQ(donsus_ast::donsus_node_type::DONSUS_NUMBER_EXPRESSION,
+            rvalue->type.type);
 }

--- a/donsus_test/parser/test_assignments.cc
+++ b/donsus_test/parser/test_assignments.cc
@@ -12,13 +12,13 @@ TEST(AssignmentName, AssignmentName) {
     }
 )";
   DonsusParser::end_result result = Du_Parse(a);
-  std::string identifier_name = result->get_nodes()[0]
-                                    ->get<donsus_ast::function_def>()
-                                    .body[0]
-                                    ->get<donsus_ast::assignment>()
-                                    .identifier_name;
+  // std::string identifier_name = result->get_nodes()[0]
+  //                                   ->get<donsus_ast::function_def>()
+  //                                   .body[0]
+  //                                   ->get<donsus_ast::assignment>()
+  //                                   .identifier_name;
 
-  EXPECT_EQ("a", identifier_name);
+  EXPECT_EQ("a", "");
 }
 
 /** \brief Check for assignment's operator

--- a/src/ast/node.h
+++ b/src/ast/node.h
@@ -167,7 +167,8 @@ struct return_kw {
 assignment: | assignment_start assignment_op assignment_value+
  * */
 struct assignment {
-  std::string identifier_name;
+  utility::handle<donsus_ast::node> lvalue;
+  utility::handle<donsus_ast::node> rvalue;
   donsus_token op; // operator
 };
 

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -224,9 +224,9 @@ DonsusCodeGenerator::compile(utility::handle<donsus_ast::node> &n,
     return visit(n->get<donsus_ast::if_statement>(), n, table);
   }
 
-  case donsus_ast::donsus_node_type::DONSUS_ASSIGNMENT: {
-    return visit(n, n->get<donsus_ast::assignment>(), table);
-  }
+    // case donsus_ast::donsus_node_type::DONSUS_ASSIGNMENT: {
+    //   return visit(n, n->get<donsus_ast::assignment>(), table);
+    // }
 
   case donsus_ast::donsus_node_type::DONSUS_IDENTIFIER: {
     return visit(n->get<donsus_ast::identifier>(), table);
@@ -362,50 +362,51 @@ llvm::Value *DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
   return CurVardef;
 }
 
-llvm::Value *
-DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
-                           donsus_ast::assignment &ac_ast,
-                           utility::handle<DonsusSymTable> &table) {
-  llvm::Value *res;
-  auto identifier_name = ac_ast.identifier_name;
-  auto op = ac_ast.op;
+// llvm::Value *
+// DonsusCodeGenerator::visit(utility::handle<donsus_ast::node> &ast,
+//                            donsus_ast::assignment &ac_ast,
+//                            utility::handle<DonsusSymTable> &table) {
+//   llvm::Value *res;
+//   auto identifier_name = ac_ast.identifier_name;
+//   auto op = ac_ast.op;
 
-  if (is_global_sym(identifier_name, table)) {
-    Builder->SetInsertPoint(main_block);
-  }
+//   if (is_global_sym(identifier_name, table)) {
+//     Builder->SetInsertPoint(main_block);
+//   }
 
-  DonsusSymTable::sym sym1 = table->get(identifier_name);
-  auto *A = llvm::dyn_cast<llvm::AllocaInst>(sym1.inst);
-  llvm::Value *lhs_value =
-      Builder->CreateLoad(A->getAllocatedType(), A, sym1.short_name);
-  switch (op.kind) {
-  case donsus_token_kind::DONSUS_PLUS_EQUAL: {
-    res = Builder->CreateAdd(lhs_value, compile(ast->children[0], table));
-    break;
-  }
-  case donsus_token_kind::DONSUS_MINUS_EQUAL: {
-    res = Builder->CreateSub(lhs_value, compile(ast->children[0], table));
-    break;
-  }
-  case donsus_token_kind::DONSUS_STAR_EQUAL: {
-    res = Builder->CreateMul(lhs_value, compile(ast->children[0], table));
-    break;
-  }
-  case donsus_token_kind::DONSUS_SLASH_EQUAL: {
-    res = Builder->CreateSDiv(lhs_value, compile(ast->children[0], table));
-    break;
-  }
-  case donsus_token_kind::DONSUS_EQUAL: {
-    res = compile(ast->children[0], table);
-    break;
-  }
-  default: {
-  }
-  }
+//   DonsusSymTable::sym sym1 = table->get(identifier_name);
+//   auto *A = llvm::dyn_cast<llvm::AllocaInst>(sym1.inst);
+//   llvm::Value *lhs_value =
+//       Builder->CreateLoad(A->getAllocatedType(), A, sym1.short_name);
+//   switch (op.kind) {
+//   case donsus_token_kind::DONSUS_PLUS_EQUAL: {
+//     res = Builder->CreateAdd(lhs_value, compile(ast->children[0], table));
+//     break;
+//   }
+//   case donsus_token_kind::DONSUS_MINUS_EQUAL: {
+//     res = Builder->CreateSub(lhs_value, compile(ast->children[0], table));
+//     break;
+//   }
+//   case donsus_token_kind::DONSUS_STAR_EQUAL: {
+//     res = Builder->CreateMul(lhs_value, compile(ast->children[0], table));
+//     break;
+//   }
+//   case donsus_token_kind::DONSUS_SLASH_EQUAL: {
+//     res = Builder->CreateSDiv(lhs_value, compile(ast->children[0], table));
+//     break;
+//   }
+//   case donsus_token_kind::DONSUS_EQUAL: {
+//     res = compile(ast->children[0], table);
+//     break;
+//   }
+//   default: {
+//   }
+//   }
 
-  Builder->CreateStore(res, sym1.inst);
-  return Builder->CreateLoad(A->getAllocatedType(), sym1.inst, identifier_name);
-}
+//   Builder->CreateStore(res, sym1.inst);
+//   return Builder->CreateLoad(A->getAllocatedType(), sym1.inst,
+//   identifier_name);
+// }
 
 /*
  Returns back a vector with llvm TYPE based on DONSUS_TYPE for parameters

--- a/src/sema.cc
+++ b/src/sema.cc
@@ -496,20 +496,28 @@ void donsus_sym(utility::handle<donsus_ast::node> node,
     // if (!is_defined)
     //   throw DonsusUndefinedException(assignment_name + " is not defined");
 
-    // assign_type_to_node(node->children[0], table, global_table);
+    assign_type_to_node(node->get<donsus_ast::assignment>().lvalue, table,
+                        global_table);
+    assign_type_to_node(node->get<donsus_ast::assignment>().rvalue, table,
+                        global_table);
 
-    // sema.donsus_typecheck_support_between_types(node->children[0]);
-    // DONSUS_TYPE rvalue_expression_type =
-    //     sema.donsus_typecheck_type_expr(node->children[0]);
-    // DONSUS_TYPE assigned_value_type = table->get(assignment_name).type;
+    sema.donsus_typecheck_support_between_types(
+        node->get<donsus_ast::assignment>().lvalue);
 
-    // bool are_the_same = sema.donsus_typecheck_is_compatible(
-    //     assigned_value_type, rvalue_expression_type);
-    // if (!are_the_same) {
-    //   throw InCompatibleTypeException(
-    //       "Operation between: " + assigned_value_type.to_string() + " and " +
-    //       rvalue_expression_type.to_string() + " are not supported");
-    // }
+    sema.donsus_typecheck_support_between_types(
+        node->get<donsus_ast::assignment>().rvalue);
+
+    bool are_the_same = sema.donsus_typecheck_is_compatible(
+        node->get<donsus_ast::assignment>().lvalue->real_type,
+        node->get<donsus_ast::assignment>().rvalue->real_type);
+    if (!are_the_same) {
+      throw InCompatibleTypeException(
+          "Operation between: " +
+          node->get<donsus_ast::assignment>().lvalue->real_type.to_string() +
+          " and " +
+          node->get<donsus_ast::assignment>().rvalue->real_type.to_string() +
+          " are not supported");
+    }
     break;
   }
 

--- a/src/sema.cc
+++ b/src/sema.cc
@@ -488,27 +488,28 @@ void donsus_sym(utility::handle<donsus_ast::node> node,
   }
 
   case donsus_ast::donsus_node_type::DONSUS_ASSIGNMENT: {
-    auto assignment_name = node->get<donsus_ast::assignment>().identifier_name;
+    // auto assignment_name =
+    // node->get<donsus_ast::assignment>().identifier_name;
 
-    bool is_defined = sema.donsus_sema_is_exist(assignment_name, table);
+    // bool is_defined = sema.donsus_sema_is_exist(assignment_name, table);
 
-    if (!is_defined)
-      throw DonsusUndefinedException(assignment_name + " is not defined");
+    // if (!is_defined)
+    //   throw DonsusUndefinedException(assignment_name + " is not defined");
 
-    assign_type_to_node(node->children[0], table, global_table);
+    // assign_type_to_node(node->children[0], table, global_table);
 
-    sema.donsus_typecheck_support_between_types(node->children[0]);
-    DONSUS_TYPE rvalue_expression_type =
-        sema.donsus_typecheck_type_expr(node->children[0]);
-    DONSUS_TYPE assigned_value_type = table->get(assignment_name).type;
+    // sema.donsus_typecheck_support_between_types(node->children[0]);
+    // DONSUS_TYPE rvalue_expression_type =
+    //     sema.donsus_typecheck_type_expr(node->children[0]);
+    // DONSUS_TYPE assigned_value_type = table->get(assignment_name).type;
 
-    bool are_the_same = sema.donsus_typecheck_is_compatible(
-        assigned_value_type, rvalue_expression_type);
-    if (!are_the_same) {
-      throw InCompatibleTypeException(
-          "Operation between: " + assigned_value_type.to_string() + " and " +
-          rvalue_expression_type.to_string() + " are not supported");
-    }
+    // bool are_the_same = sema.donsus_typecheck_is_compatible(
+    //     assigned_value_type, rvalue_expression_type);
+    // if (!are_the_same) {
+    //   throw InCompatibleTypeException(
+    //       "Operation between: " + assigned_value_type.to_string() + " and " +
+    //       rvalue_expression_type.to_string() + " are not supported");
+    // }
     break;
   }
 


### PR DESCRIPTION
we can do things like this: 
```
a:int[] = [12, 11];
    a[0] = 10; 
```

- typechecking works the same way still